### PR TITLE
Install requires added to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,16 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setuptools.setup(name='sciencebasepy',
-      version='1.6.4',
-      author="USGS ScienceBase Development Team",
-      author_email="sciencebase@usgs.gov",
-      description="Python ScienceBase Utilities",
-      long_description=long_description,
-      url='https://github.com/usgs/sciencebasepy',
-      packages=setuptools.find_packages(),
-      classifiers=[        
+setuptools.setup(
+    name='sciencebasepy',
+    version='1.6.5',
+    author="USGS ScienceBase Development Team",
+    author_email="sciencebase@usgs.gov",
+    description="Python ScienceBase Utilities",
+    long_description=long_description,
+    url='https://github.com/usgs/sciencebasepy',
+    packages=setuptools.find_packages(),
+    classifiers=[
         "License :: Public Domain",
         "Operating System :: OS Independent",
         'Programming Language :: Python',
@@ -23,5 +24,8 @@ setuptools.setup(name='sciencebasepy',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6'
-      ],
-      )
+    ],
+    install_requires=[
+        "requests"
+    ]
+)


### PR DESCRIPTION
Added an install_requires to the setup.py with the requests package. I noticed this was missing in a recent clean environment install. Requests seems to be the only additional package beyond a Python base that I can see in the code. I incremented the version to 1.6.5.