### PR TITLE
Add optional encoding parameter to sb_session get function

### DIFF
--- a/sciencebasepy/SbSession.py
+++ b/sciencebasepy/SbSession.py
@@ -815,13 +815,18 @@ class SbSession:
         """
         return self.find_items({'q': '', 'lq': 'title:"' + text + '"'})
 
-    def get(self, url):
+    def get(self, url, encoding = None):
         """Get the text response of the given URL
 
         :param url: URL to request via HTTP GET
+		:param encoding: Encoding string ("utf-8", "ISO-8859-1", etc.)
         :return: TEXT response
         """
-        return self._get_text(self._session.get(url))
+		response = self._session.get(url)
+		if encoding is not None:
+			response.encoding = encoding
+		
+        return self._get_text(response)
 
     def get_json(self, url, params = None):
         """Get the JSON response of the given URL


### PR DESCRIPTION
I was running into an issue when getting the contents of an xml file, where non ascii characters were getting scrambled because the default encoding is latin-1.  There needs to be a way to specify the encoding when performing a requests.get.  My preference would be to have this default to 'utf-8' but I set it to None for now.  'utf-8'  would return the same results as latin-1 in cases of only having ascii characters, but also function appropriately for utf-8 and unicode files (I think).